### PR TITLE
Fix performance dips and BepInEx port

### DIFF
--- a/CM3D2.CameraControlEx.Plugin/CM3D2.CameraControlEx.Plugin.csproj
+++ b/CM3D2.CameraControlEx.Plugin/CM3D2.CameraControlEx.Plugin.csproj
@@ -7,10 +7,12 @@
     <ProjectGuid>{255101D1-B097-4334-8EA3-4A84D95EC9A4}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>CM3D2.CameraControlEx.Plugin</RootNamespace>
-    <AssemblyName>CM3D2.CameraControlEx.Plugin</AssemblyName>
+    <RootNamespace>COM3D2.CameraControlEx.Plugin</RootNamespace>
+    <AssemblyName>COM3D2.CameraControlEx.Plugin</AssemblyName>
     <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -30,37 +32,54 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Assembly-CSharp">
-      <HintPath>..\References\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\HarmonyX.2.5.5\lib\net35\0Harmony.dll</HintPath>
     </Reference>
-    <Reference Include="ExIni, Version=1.0.2.0, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\ExIni.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\COM3D2.GameLibs.2.8.0-r.0\lib\net35\Assembly-CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\COM3D2.GameLibs.2.8.0-r.0\lib\net35\Assembly-CSharp-firstpass.dll</HintPath>
+    </Reference>
+    <Reference Include="BepInEx, Version=5.4.15.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\BepInEx.BaseLib.5.4.16\lib\net35\BepInEx.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.4\lib\net35\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.4\lib\net35\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.4\lib\net35\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks, Version=0.10.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
+      <HintPath>..\packages\Mono.Cecil.0.10.4\lib\net35\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.RuntimeDetour.21.8.19.1\lib\net35\MonoMod.RuntimeDetour.dll</HintPath>
+    </Reference>
+    <Reference Include="MonoMod.Utils, Version=21.8.19.1, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\MonoMod.Utils.21.8.19.1\lib\net35\MonoMod.Utils.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\UnityEngine.dll</HintPath>
-      <Private>False</Private>
+      <HintPath>..\packages\UnityEngine.5.6.1\lib\net35\UnityEngine.dll</HintPath>
     </Reference>
-    <Reference Include="UnityInjector, Version=1.0.0.1, Culture=neutral, processorArchitecture=x86">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\References\UnityInjector.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\COM3D2.GameLibs.2.8.0-r.0\lib\net35\UnityEngine.UI.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="CameraControlExPlugin.Properties.cs" />
-    <Compile Include="CameraControlExPlugin.Unity.cs" />
-    <Compile Include="CameraControlExPlugin.cs" />
     <Compile Include="CameraControlExPlugin.Generated.cs">
       <AutoGen>True</AutoGen>
       <DesignTime>True</DesignTime>
       <DependentUpon>CameraControlExPlugin.Generated.tt</DependentUpon>
     </Compile>
+    <Compile Include="CameraControlExPlugin.Properties.cs" />
+    <Compile Include="CameraControlExPlugin.Unity.cs" />
+    <Compile Include="CameraControlExPlugin.cs" />
     <Compile Include="Extensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -68,6 +87,7 @@
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="PluginConfigTemplate.tt" />
     <None Include="CameraControlExPlugin.Generated.tt">
       <Generator>TextTemplatingFileGenerator</Generator>
@@ -75,6 +95,13 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets" Condition="Exists('..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CM3D2.CameraControlEx.Plugin/CM3D2.CameraControlEx.Plugin.csproj
+++ b/CM3D2.CameraControlEx.Plugin/CM3D2.CameraControlEx.Plugin.csproj
@@ -102,6 +102,9 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\BepInEx.Core.5.4.16\build\BepInEx.Core.targets'))" />
   </Target>
+  <PropertyGroup>
+    <PostBuildEvent>copy "$(TargetPath)" "F:\COM-3d2\BepinEx\plugins\"</PostBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Generated.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Generated.cs
@@ -1,5 +1,5 @@
 // ------------------------------------
-// Auto-Generated with T4 Templating on Microsoft Visual Studio 14.0
+// Auto-Generated with T4 Templating on Microsoft Visual Studio 16.0
 // Template File: CameraControlExPlugin.Generated.tt
 // ------------------------------------
 // Install T4 Toolbox if having troubles
@@ -10,130 +10,124 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 
 using UnityEngine;
+using BepInEx.Configuration;
 
-namespace CM3D2.CameraControlEx.Plugin
+
+namespace COM3D2.CameraControlEx.Plugin
 {
     partial class CameraControlExPlugin
     {
         [CompilerGenerated]
         partial void InitConfig() {
-            bool changed = false;
-            changed |= InitConfig("Config", "EyeToCam", KeyCode.KeypadPeriod);
-            changed |= InitConfig("Config", "FOVReset", KeyCode.KeypadMultiply);
-            changed |= InitConfig("Config", "Modifier", KeyCode.LeftAlt);
-            changed |= InitConfig("Config", "MoveBackward", KeyCode.Keypad2);
-            changed |= InitConfig("Config", "MoveDown", KeyCode.Keypad1);
-            changed |= InitConfig("Config", "MoveForward", KeyCode.Keypad8);
-            changed |= InitConfig("Config", "MoveLeft", KeyCode.Keypad4);
-            changed |= InitConfig("Config", "MoveRight", KeyCode.Keypad6);
-            changed |= InitConfig("Config", "MoveUp", KeyCode.Keypad3);
-            changed |= InitConfig("Config", "Reset", KeyCode.Keypad5);
-            changed |= InitConfig("Config", "Screenshot", KeyCode.Keypad0);
-            changed |= InitConfig("Config", "ToggleFine", KeyCode.KeypadDivide);
-            changed |= InitConfig("Config", "ZoomIn", KeyCode.KeypadPlus);
-            changed |= InitConfig("Config", "ZoomOut", KeyCode.KeypadMinus);
-            changed |= InitConfig("Config", "FOV", -1f);
-            changed |= InitConfig("Config", "FOVChange", 0.25f);
-            changed |= InitConfig("Config", "MoveRate", 0.05f);
-            changed |= InitConfig("Config", "SpinRate", 1f);
-            if(changed)
-            	SaveConfig();
+            ConfigEntryEyeToCam = Config.Bind("Config", "EyeToCam", KeyCode.KeypadPeriod);
+            ConfigEntryFOVReset = Config.Bind("Config", "FOVReset", KeyCode.KeypadMultiply);
+            ConfigEntryModifier = Config.Bind("Config", "Modifier", KeyCode.LeftAlt);
+            ConfigEntryMoveBackward = Config.Bind("Config", "MoveBackward", KeyCode.Keypad2);
+            ConfigEntryMoveDown = Config.Bind("Config", "MoveDown", KeyCode.Keypad1);
+            ConfigEntryMoveForward = Config.Bind("Config", "MoveForward", KeyCode.Keypad8);
+            ConfigEntryMoveLeft = Config.Bind("Config", "MoveLeft", KeyCode.Keypad4);
+            ConfigEntryMoveRight = Config.Bind("Config", "MoveRight", KeyCode.Keypad6);
+            ConfigEntryMoveUp = Config.Bind("Config", "MoveUp", KeyCode.Keypad3);
+            ConfigEntryReset = Config.Bind("Config", "Reset", KeyCode.Keypad5);
+            ConfigEntryScreenshot = Config.Bind("Config", "Screenshot", KeyCode.Keypad0);
+            ConfigEntryToggleFine = Config.Bind("Config", "ToggleFine", KeyCode.KeypadDivide);
+            ConfigEntryZoomIn = Config.Bind("Config", "ZoomIn", KeyCode.KeypadPlus);
+            ConfigEntryZoomOut = Config.Bind("Config", "ZoomOut", KeyCode.KeypadMinus);
+            ConfigEntryFOV = Config.Bind("Config", "FOV", -1f);
+            ConfigEntryFOVChange = Config.Bind("Config", "FOVChange", 0.25f);
+            ConfigEntryMoveRate = Config.Bind("Config", "MoveRate", 0.05f);
+            ConfigEntrySpinRate = Config.Bind("Config", "SpinRate", 1f);
         }
         
         [CompilerGenerated]
-        private KeyCode EyeToCam => ParseEnum(Preferences["Config"]["EyeToCam"].Value, KeyCode.KeypadPeriod);
+        private ConfigEntry<KeyCode> ConfigEntryEyeToCam;
+        [CompilerGenerated]
+        private KeyCode EyeToCam => ConfigEntryEyeToCam.Value;
         
         [CompilerGenerated]
-        private KeyCode FOVReset => ParseEnum(Preferences["Config"]["FOVReset"].Value, KeyCode.KeypadMultiply);
+        private ConfigEntry<KeyCode> ConfigEntryFOVReset;
+        [CompilerGenerated]
+        private KeyCode FOVReset => ConfigEntryFOVReset.Value;
         
         [CompilerGenerated]
-        private KeyCode Modifier => ParseEnum(Preferences["Config"]["Modifier"].Value, KeyCode.LeftAlt);
+        private ConfigEntry<KeyCode> ConfigEntryModifier;
+        [CompilerGenerated]
+        private KeyCode Modifier => ConfigEntryModifier.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveBackward => ParseEnum(Preferences["Config"]["MoveBackward"].Value, KeyCode.Keypad2);
+        private ConfigEntry<KeyCode> ConfigEntryMoveBackward;
+        [CompilerGenerated]
+        private KeyCode MoveBackward => ConfigEntryMoveBackward.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveDown => ParseEnum(Preferences["Config"]["MoveDown"].Value, KeyCode.Keypad1);
+        private ConfigEntry<KeyCode> ConfigEntryMoveDown;
+        [CompilerGenerated]
+        private KeyCode MoveDown => ConfigEntryMoveDown.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveForward => ParseEnum(Preferences["Config"]["MoveForward"].Value, KeyCode.Keypad8);
+        private ConfigEntry<KeyCode> ConfigEntryMoveForward;
+        [CompilerGenerated]
+        private KeyCode MoveForward => ConfigEntryMoveForward.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveLeft => ParseEnum(Preferences["Config"]["MoveLeft"].Value, KeyCode.Keypad4);
+        private ConfigEntry<KeyCode> ConfigEntryMoveLeft;
+        [CompilerGenerated]
+        private KeyCode MoveLeft => ConfigEntryMoveLeft.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveRight => ParseEnum(Preferences["Config"]["MoveRight"].Value, KeyCode.Keypad6);
+        private ConfigEntry<KeyCode> ConfigEntryMoveRight;
+        [CompilerGenerated]
+        private KeyCode MoveRight => ConfigEntryMoveRight.Value;
         
         [CompilerGenerated]
-        private KeyCode MoveUp => ParseEnum(Preferences["Config"]["MoveUp"].Value, KeyCode.Keypad3);
+        private ConfigEntry<KeyCode> ConfigEntryMoveUp;
+        [CompilerGenerated]
+        private KeyCode MoveUp => ConfigEntryMoveUp.Value;
         
         [CompilerGenerated]
-        private KeyCode Reset => ParseEnum(Preferences["Config"]["Reset"].Value, KeyCode.Keypad5);
+        private ConfigEntry<KeyCode> ConfigEntryReset;
+        [CompilerGenerated]
+        private KeyCode Reset => ConfigEntryReset.Value;
         
         [CompilerGenerated]
-        private KeyCode Screenshot => ParseEnum(Preferences["Config"]["Screenshot"].Value, KeyCode.Keypad0);
+        private ConfigEntry<KeyCode> ConfigEntryScreenshot;
+        [CompilerGenerated]
+        private KeyCode Screenshot => ConfigEntryScreenshot.Value;
         
         [CompilerGenerated]
-        private KeyCode ToggleFine => ParseEnum(Preferences["Config"]["ToggleFine"].Value, KeyCode.KeypadDivide);
+        private ConfigEntry<KeyCode> ConfigEntryToggleFine;
+        [CompilerGenerated]
+        private KeyCode ToggleFine => ConfigEntryToggleFine.Value;
         
         [CompilerGenerated]
-        private KeyCode ZoomIn => ParseEnum(Preferences["Config"]["ZoomIn"].Value, KeyCode.KeypadPlus);
+        private ConfigEntry<KeyCode> ConfigEntryZoomIn;
+        [CompilerGenerated]
+        private KeyCode ZoomIn => ConfigEntryZoomIn.Value;
         
         [CompilerGenerated]
-        private KeyCode ZoomOut => ParseEnum(Preferences["Config"]["ZoomOut"].Value, KeyCode.KeypadMinus);
+        private ConfigEntry<KeyCode> ConfigEntryZoomOut;
+        [CompilerGenerated]
+        private KeyCode ZoomOut => ConfigEntryZoomOut.Value;
         
         [CompilerGenerated]
-        private Single FOV => ParseConvertible(Preferences["Config"]["FOV"].Value, -1f);
+        private ConfigEntry<Single> ConfigEntryFOV;
+        [CompilerGenerated]
+        private Single FOV => ConfigEntryFOV.Value;
         
         [CompilerGenerated]
-        private Single FOVChange => ParseConvertible(Preferences["Config"]["FOVChange"].Value, 0.25f);
+        private ConfigEntry<Single> ConfigEntryFOVChange;
+        [CompilerGenerated]
+        private Single FOVChange => ConfigEntryFOVChange.Value;
         
         [CompilerGenerated]
-        private Single MoveRate => ParseConvertible(Preferences["Config"]["MoveRate"].Value, 0.05f);
+        private ConfigEntry<Single> ConfigEntryMoveRate;
+        [CompilerGenerated]
+        private Single MoveRate => ConfigEntryMoveRate.Value;
         
         [CompilerGenerated]
-        private Single SpinRate => ParseConvertible(Preferences["Config"]["SpinRate"].Value, 1f);
-
+        private ConfigEntry<Single> ConfigEntrySpinRate;
         [CompilerGenerated]
-        private bool InitConfig(string section, string key, object value)
-        {
-            if (!Preferences.HasSection(section)
-                || !Preferences[section].HasKey(key)
-                || string.IsNullOrEmpty(Preferences[section][key].Value))
-            {
-                Preferences[section][key].Value = value.ToString();
-                return true;
-            }
-            return false;
-        }
-
-        [CompilerGenerated]
-        private static T ParseConvertible<T>(string value, T @default) where T : IConvertible
-        {
-            T retVal;
-            try
-            {
-                retVal = (T) ((IConvertible) value).ToType(typeof (T), CultureInfo.InvariantCulture);
-            }
-            catch
-            {
-                retVal = @default;
-            }
-            return retVal;
-        }
-
-        [CompilerGenerated]
-        private static T ParseEnum<T>(string value, T @default)
-            where T : struct, IConvertible
-        {
-            var exists = string.IsNullOrEmpty(value)
-                ? false
-                : Enum.IsDefined(typeof (T), value);
-            return exists
-                ? (T) Enum.Parse(typeof (T), value)
-                : @default;
-        }
-
+        private Single SpinRate => ConfigEntrySpinRate.Value;
  
     }
 }

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Generated.tt
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Generated.tt
@@ -1,7 +1,7 @@
 <#@ template language="C#" hostspecific="true" #>
 <#@ output extension=".cs" #>
 <# /* Change Unity Engine Path */ #>
-<#@ assembly name="$(SolutionDir)References\UnityEngine.dll" #>
+<#@ assembly name="$(SolutionDir)packages\UnityEngine.5.6.1\lib\net35\UnityEngine.dll" #>
 <# /* ------------------------ */ #>
 <#@ import namespace="System" #>
 <#@ import namespace="UnityEngine" #>
@@ -25,7 +25,7 @@
     Properties.Add("Modifier", KeyCode.LeftAlt);
     Properties.Add("Screenshot", KeyCode.Keypad0);
     Properties.Add("Reset", KeyCode.Keypad5);
-
+       
     Properties.Add("MoveUp", KeyCode.Keypad3);
     Properties.Add("MoveDown", KeyCode.Keypad1);
     Properties.Add("MoveLeft", KeyCode.Keypad4);

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Properties.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Properties.cs
@@ -4,7 +4,7 @@
 
 using UnityEngine;
 
-namespace CM3D2.CameraControlEx.Plugin
+namespace COM3D2.CameraControlEx.Plugin
 {
     partial class CameraControlExPlugin
     {

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Unity.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Unity.cs
@@ -7,7 +7,7 @@ using System.Reflection;
 
 using UnityEngine;
 
-namespace CM3D2.CameraControlEx.Plugin
+namespace COM3D2.CameraControlEx.Plugin
 {
     partial class CameraControlExPlugin
     {

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Unity.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.Unity.cs
@@ -4,15 +4,27 @@
 
 using System;
 using System.Reflection;
+using System.IO;
 
 using UnityEngine;
+using BepInEx;
+using BepInEx.Configuration;
+using HarmonyLib;
+using HarmonyLib.Tools;
 
 namespace COM3D2.CameraControlEx.Plugin
 {
     partial class CameraControlExPlugin
     {
+        public void Awake()
+        {
+            OldConfigCheck();
+            InitConfig();
+        }
+
         public void OnLevelWasLoaded(int level)
         {
+            SybarisCheck();
             FirstUpdate = true;
         }
 
@@ -48,6 +60,36 @@ namespace COM3D2.CameraControlEx.Plugin
                 HandleRotation();
             else
                 HandleMovement();
+        }
+
+        private void OldConfigCheck()
+        {
+            var oldConfigPath = Path.Combine(Paths.GameRootPath, "Sybaris\\UnityInjector\\Config\\CameraControlExPlugin.ini");
+            if (File.Exists(oldConfigPath))
+            {
+                Logger.LogWarning($"Detected old sybaris configuration at [{oldConfigPath}]. Make sure to migrate your configuration to the new configuration path. See plugin README.md for details.");
+                this.transitionalConfigFile = new ConfigFile(oldConfigPath, false);
+            }
+        }
+
+        private void SybarisCheck()
+        {
+            var injector = GameObject.Find("UnityInjector");
+            var component = injector?.GetComponent("CameraControlExPlugin");
+            
+            if(component != null)
+            {
+                var assemblyLocation = component.GetType().Assembly.Location;
+                Logger.LogWarning($"Detected old sybaris plugin at [{assemblyLocation}]. Disabling this plugin but you are advised to uninstall this properly. See plugin README.md for details.");
+                GameObject.Destroy(component);
+            }
+        }
+
+        private ConfigFile transitionalConfigFile;
+
+        new ConfigFile Config
+        {
+            get => transitionalConfigFile ?? base.Config;
         }
     }
 }

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.cs
@@ -4,18 +4,12 @@
 
 using UnityEngine;
 
-using UnityInjector;
-using UnityInjector.Attributes;
+using BepInEx;
 
-namespace CM3D2.CameraControlEx.Plugin
+namespace COM3D2.CameraControlEx.Plugin
 {
-    [PluginName("Extended Camera Controls")]
-    [PluginFilter("CM3D2x64")]
-    [PluginFilter("CM3D2x86")]
-    // Apparently Doesn't quite work with VR Version
-    // [PluginFilter("CM3D2VRx86")]
-    // [PluginFilter("CM3D2VRx64")]
-    public partial class CameraControlExPlugin : PluginBase
+    [BepInPlugin("org.bepinex.plugins.COM3D2.CameraControlEx", "CameraControlEx", "1.1.0.0")]
+    public partial class CameraControlExPlugin : BaseUnityPlugin
     {
         public CameraControlExPlugin()
         {

--- a/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.cs
+++ b/CM3D2.CameraControlEx.Plugin/CameraControlExPlugin.cs
@@ -8,14 +8,9 @@ using BepInEx;
 
 namespace COM3D2.CameraControlEx.Plugin
 {
-    [BepInPlugin("org.bepinex.plugins.COM3D2.CameraControlEx", "CameraControlEx", "1.1.0.0")]
+    [BepInPlugin("CameraControlExPlugin", "CameraControlEx", "1.1.0.0")]
     public partial class CameraControlExPlugin : BaseUnityPlugin
     {
-        public CameraControlExPlugin()
-        {
-            InitConfig();
-        }
-
         private void HandleHotkeys()
         {
             var cameraComponent = OrbitCamera.GetComponent<Camera>();

--- a/CM3D2.CameraControlEx.Plugin/Extensions.cs
+++ b/CM3D2.CameraControlEx.Plugin/Extensions.cs
@@ -4,7 +4,7 @@
 
 using System;
 
-namespace CM3D2.CameraControlEx.Plugin
+namespace COM3D2.CameraControlEx.Plugin
 {
     public static class Extensions
     {

--- a/CM3D2.CameraControlEx.Plugin/PluginConfigTemplate.tt
+++ b/CM3D2.CameraControlEx.Plugin/PluginConfigTemplate.tt
@@ -1,7 +1,5 @@
 <#@ template language="C#" hostspecific="true" culture="en-US" #>
 <#@ output extension="cs" #>
-<# /* Change Unity Engine Path */ #>
-<#@ assembly name="$(SolutionDir)References\UnityEngine.dll" #>
 <# /* ------------------------ */ #>
 <#@ assembly name="System.Core" #>
 <#@ assembly name="EnvDTE" #>
@@ -29,8 +27,10 @@ using System.Globalization;
 using System.Runtime.CompilerServices;
 
 using UnityEngine;
+using BepInEx.Configuration;
 
-namespace CM3D2.CameraControlEx.Plugin
+
+namespace COM3D2.CameraControlEx.Plugin
 {
     partial class <#= ClassName #>
     {
@@ -52,47 +52,6 @@ namespace CM3D2.CameraControlEx.Plugin
     PopIndent();
     PopIndent();
  #>
-
-        [CompilerGenerated]
-        private bool InitConfig(string section, string key, object value)
-        {
-            if (!Preferences.HasSection(section)
-                || !Preferences[section].HasKey(key)
-                || string.IsNullOrEmpty(Preferences[section][key].Value))
-            {
-                Preferences[section][key].Value = value.ToString();
-                return true;
-            }
-            return false;
-        }
-
-        [CompilerGenerated]
-        private static T ParseConvertible<T>(string value, T @default) where T : IConvertible
-        {
-            T retVal;
-            try
-            {
-                retVal = (T) ((IConvertible) value).ToType(typeof (T), CultureInfo.InvariantCulture);
-            }
-            catch
-            {
-                retVal = @default;
-            }
-            return retVal;
-        }
-
-        [CompilerGenerated]
-        private static T ParseEnum<T>(string value, T @default)
-            where T : struct, IConvertible
-        {
-            var exists = string.IsNullOrEmpty(value)
-                ? false
-                : Enum.IsDefined(typeof (T), value);
-            return exists
-                ? (T) Enum.Parse(typeof (T), value)
-                : @default;
-        }
-
  
     }
 }
@@ -126,12 +85,12 @@ namespace CM3D2.CameraControlEx.Plugin
         CGAttribute(true);
         WriteLine("partial void InitConfig() {");
         PushIndent("    ");
-        WriteLine("bool changed = false;");
+
         foreach(var p in props){
             string name = p.Name;
-            WriteLine("changed |= InitConfig(\"Config\", \"{0}\", {1});", name,GetValue(p));
+            WriteLine("ConfigEntry{0} = Config.Bind(\"Config\", \"{0}\", {1});", name,GetValue(p));
         }
-        WriteLine("if(changed)\r\n\tSaveConfig();");
+
         PopIndent();
         WriteLine("}");
     
@@ -148,11 +107,13 @@ namespace CM3D2.CameraControlEx.Plugin
              
             Write("\r\n");
             CGAttribute(true);
-            Write("private {0} {1} => ", type.Name, name);
-            if(type.IsEnum)
-                WriteLine("ParseEnum(Preferences[\"Config\"][\"{0}\"].Value, {1});",name, GetValue(p));
-            else if(typeof(IConvertible).IsAssignableFrom(type)) 
-                WriteLine("ParseConvertible(Preferences[\"Config\"][\"{0}\"].Value, {1});",name, GetValue(p));
+            WriteLine("private ConfigEntry<{0}> ConfigEntry{1};", type.Name, name);
+            CGAttribute(true);
+            WriteLine("private {0} {1} => ConfigEntry{1}.Value;", type.Name, name);
+            //if(type.IsEnum)
+            //    WriteLine("ParseEnum(Preferences[\"Config\"][\"{0}\"].Value, {1});",name, GetValue(p));
+            //else if(typeof(IConvertible).IsAssignableFrom(type)) 
+            //    WriteLine("ParseConvertible(Preferences[\"Config\"][\"{0}\"].Value, {1});",name, GetValue(p));
         }
         
     }

--- a/CM3D2.CameraControlEx.Plugin/Properties/AssemblyInfo.cs
+++ b/CM3D2.CameraControlEx.Plugin/Properties/AssemblyInfo.cs
@@ -13,11 +13,11 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 
-[assembly: AssemblyTitle("CM3D2 Extended Camera Control Plugin")]
+[assembly: AssemblyTitle("COM3D2 Extended Camera Control Plugin")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("CM3D2 Extended Camera Control Plugin")]
+[assembly: AssemblyProduct("COM3D2 Extended Camera Control Plugin")]
 [assembly: AssemblyCopyright("Copyright © Usagirei 2015")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -43,5 +43,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 
-[assembly: AssemblyVersion("1.0.1.1")]
-[assembly: AssemblyFileVersion("1.0.1.1")]
+[assembly: AssemblyVersion("1.1.0.0")]
+[assembly: AssemblyFileVersion("1.1.0.0")]

--- a/CM3D2.CameraControlEx.Plugin/packages.config
+++ b/CM3D2.CameraControlEx.Plugin/packages.config
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="BepInEx.BaseLib" version="5.4.16" targetFramework="net35" />
+  <package id="BepInEx.Core" version="5.4.16" targetFramework="net35" />
+  <package id="COM3D2.GameLibs" version="2.8.0-r.0" targetFramework="net35" />
+  <package id="HarmonyX" version="2.5.5" targetFramework="net35" />
+  <package id="Mono.Cecil" version="0.10.4" targetFramework="net35" />
+  <package id="MonoMod.RuntimeDetour" version="21.8.19.1" targetFramework="net35" />
+  <package id="MonoMod.Utils" version="21.8.19.1" targetFramework="net35" />
+  <package id="UnityEngine" version="5.6.1" targetFramework="net35" />
+</packages>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,22 @@
 ### Installing
 
 * Place `COM3D2.CameraControlEx.Plugin.dll` file into your BepinEx plugins folder. This is usually in `BepinEx\plugins`.
-* If you have the old Sybaris version `CM3D2.CameraControlEx.Plugin`, remove it (or uninstall it via CMI if it was installed that way)
+
+### Updating from 1.0.1.1 Sybaris
+
+This version of the plugin uses BepInEx, and use together with the old sybaris versionn is not recommended. It is advised to uninstall the Sybaris plugin to avoid control conflicts with each other.
+
+To migrate to the BepInEx version (1.1+), do the following:
+
+1. Remove the Sybaris version.
+
+If your plugins are managed via CMI, use the CMI installer to uninstall the plugin making sure clean-up actions are selected (the default). A backup of your old plugins and configurations will be made by the installer when you do this.
+
+2. Do the install steps above.
+
+3. Migrate your old settings to the new path (if you have customized keybinds)
+
+The sybaris plugin configuration is usually located at `Sybaris\UnityInjector\Config\CameraControlExPlugin.ini`. Move this file to the `BepinEx\config` folder in the root folder of your game (where COM3D2.exe is). Rename this file into **`CameraControlExPlugin.cfg`**
 
 ---
 ### Building

--- a/README.md
+++ b/README.md
@@ -1,17 +1,11 @@
 ### Installing
 
-* Place the Contents of the 'Managed' Directory into the Game 'CM3D2(x86|x64)_Data\Managed' Directory
-* Place the Contents of the 'ReiPatcher' Directory into the ReiPatcher 'Patches' Directory
-  Not the Root Directory! The Patches Directory!
-* Place the Contents of the 'UnityInjector' Directory into the 'UnityInjector' Directory at the **root** of the Game Directory, alongside the Game Exe and Data Directory
+* Place `COM3D2.CameraControlEx.Plugin.dll` file into your BepinEx plugins folder. This is usually in `BepinEx\plugins`.
+* If you have the old Sybaris version `CM3D2.CameraControlEx.Plugin`, remove it (or uninstall it via CMI if it was installed that way)
 
 ---
 ### Building
-1. Add the Reference Assemblies to the "References" Directory (using symbolic links, or by copying the files):
-* UnityEngine.dll (From Either Unity or CM3D2)
-* Assembly-CSharp.dll (From CM3D2)
-* UnityInjector.dll
-* ExIni.dll
+1. Fetch nuget packages.
 2. If Changes were made to the Plugin Configuration T4 Template, Save it so your IDE Regenerates it.
 3. Compile via your IDE or by executing "Build.bat" in the project root
 
@@ -36,4 +30,4 @@
 | NumpadMultiply | Reset FOV                 |                         |
 | Keypad0        | ScreenShot                | ScreenShot (No UI)      |
 
-*Change Keybinds and Rotation/Movement Speed in in the Configuration File "UnityInjector\Config\CameraControlExPlugin.ini"*
+*Change Keybinds and Rotation/Movement Speed in in the Configuration File `BepinEx\config\org.bepinex.plugins.COM3D2.CameraControlEx.cfg`*


### PR DESCRIPTION
There was a recent discussion in Custom Maid Server discord regarding CameraControlEx causing possible performance dips in certain configurations. Discussion of it starts here: https://discord.com/channels/297072643797155840/416654703951216640/911320040853352461

It was found that the plugin keeps reading the configuration file every update frame, along with some allocation oddities due to enum parsing that may cause further allocation that make GC more frequent. This in turn results in more frequent stuttering specially in motion heavy scenes (like dances).

This PR resolves that issue by:

- Porting to use BepInEx to use its more robust builtin configuration classes (which better handles configuration and enum conversion)
- Added routines for handling when upgrading from sybaris, by disabling old the plugin if it was running and reusing old keybinds if they exist